### PR TITLE
Remove nonexistent $ref'd file

### DIFF
--- a/.bluemix/deploy.json
+++ b/.bluemix/deploy.json
@@ -1,9 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "Sample Deploy Stage",
-    "localized-struct":{
-        "$ref": "deploy-localized-struct.json"
-    },
     "description": "sample toolchain",
     "longDescription": "The Delivery Pipeline automates continuous deployment.",
     "type": "object",


### PR DESCRIPTION
This template repo currently doesn't load in the [Devops Toolchain page](https://console.ng.bluemix.net/devops/setup/deploy?repository=https://github.com/IBMCloudDevOps/bluemix-php-sample).

The cause is a `$ref` to a nonexistent `deploy-localized-struct.json` file. This pull request fixes it.

![php-repo](https://cloud.githubusercontent.com/assets/382404/25674525/215e1864-3009-11e7-95f4-fd255c6970e3.png)
